### PR TITLE
fix. bug in none-retina display

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -89,9 +89,10 @@ export default class Image extends Component {
 
     if (!isCheckingDone) {
       const isRetinaDisplay = isRetina();
+      const isSrcArrayed = Array.isArray(src);
 
-      if (isRetinaDisplay) {
-        if (Array.isArray(src)) {
+      if (isRetinaDisplay || isSrcArrayed) {
+        if (isSrcArrayed) {
           const retinaImage = src[1];
 
           imageExists(retinaImage, (exists) => {


### PR DESCRIPTION
**Description:**
- On none-retina display, image was not rendered.

**Changes proposed:**
- change condition of `setState` in `checkRetina` method.